### PR TITLE
Bugfix/uge/follow status

### DIFF
--- a/src/hpce_utils/managers/uge/status.py
+++ b/src/hpce_utils/managers/uge/status.py
@@ -54,7 +54,7 @@ COLUMN_JOB = "job"
 COLUMN_JOB_ID = "job_number"
 COLUMN_SUBMISSION_TIME = "submission_time"
 COLUMN_TASKARRAY = "job-array tasks"
-
+#
 
 class TaskarrayProgress:
     def __init__(


### PR DESCRIPTION
We've seen issues where the follow_status function suggested that a job was finished (presumably based on an empty stdout), while the jobs were actually still running. It is not clear what lead to this, but it must be due to some kind of error happening in the execution of "qstat". 

This PR adds error handling to the execution of any shell commands (non-zero exit status will lead to raising an error), and handles such errors if they should occur for qstat. Since we exceute qstat regularly, a single error should not terminate our process, hence a failed command is repeated. 

I have switched from subprocess.Popen to subprocess.run following the latest suggestions on how to use the subprocess module. 