### PR TITLE
Bugfix/qstat error

### DIFF
--- a/src/hpce_utils/managers/uge/status.py
+++ b/src/hpce_utils/managers/uge/status.py
@@ -515,7 +515,7 @@ def get_qacctj(job_id: Union[str, int]) -> pd.DataFrame:
         if exc.returncode == 1 and "not found" in exc.stderr and job_id in exc.stderr:
             # conclude that job is not finished
             logger.info(f"Job {job_id} not found in qacct")
-            return pd.DataFrame({})
+            return pd.DataFrame({}), exc.stderr
 
         raise exc
 
@@ -574,7 +574,7 @@ def wait_for_jobs(
     logger.info(f"All jobs finished and took {diff_time/60/60:.2f}h")
 
 
-def wait_for_jobs_without_qstat(
+def wait_for_jobs_using_hold_job(
     jobs: list[str],
     scr: Path,
     user_email: str | None = None,

--- a/src/hpce_utils/managers/uge/status.py
+++ b/src/hpce_utils/managers/uge/status.py
@@ -350,6 +350,7 @@ def follow_progress(
     qstat, qstatu_log_str = get_qstat(
         username, max_retries=max_retries, update_interval=update_interval
     )
+    print(qstat)
 
     if not len(qstat):
         logger.warning(f"No jobs for {username}")
@@ -377,6 +378,7 @@ def follow_progress(
         if job.running + job.pending == 0 and job.error > 0:
             # crashed job
             errors = _get_errors_from_qstatj(qstatj)
+            print(errors)
             logger.error(f"UGE job {job_id} is NOT starting for the following reason(s):")
             for error in errors:
                 logger.error(error)

--- a/src/hpce_utils/managers/uge/status.py
+++ b/src/hpce_utils/managers/uge/status.py
@@ -350,7 +350,6 @@ def follow_progress(
     qstat, qstatu_log_str = get_qstat(
         username, max_retries=max_retries, update_interval=update_interval
     )
-    print(qstat)
 
     if not len(qstat):
         logger.warning(f"No jobs for {username}")
@@ -378,7 +377,6 @@ def follow_progress(
         if job.running + job.pending == 0 and job.error > 0:
             # crashed job
             errors = _get_errors_from_qstatj(qstatj)
-            print(errors)
             logger.error(f"UGE job {job_id} is NOT starting for the following reason(s):")
             for error in errors:
                 logger.error(error)
@@ -432,7 +430,6 @@ def follow_progress(
                     array_bar.job_id, cross_check=True, n_total_jobs=array_bar.n_total
                 ):
                     array_bar.finish()
-                    array_bar.log_errors()
                 else:
                     logger.warning(
                         f"Job {array_bar.job_id} not found in qstat, but cross-check showed it is not finished"
@@ -443,7 +440,6 @@ def follow_progress(
                             f"Cross check failed for job {array_bar.job_id} 5 times in a row. Assuming it is finished."
                         )
                         array_bar.finish()
-                        array_bar.log_errors()
 
             continue
 
@@ -464,7 +460,6 @@ def follow_progress(
                     array_bar.job_id, cross_check=True, n_total_jobs=array_bar.n_total
                 ):
                     array_bar.finish()
-                    array_bar.log_errors()
                 else:
                     logger.warning(
                         f"Job {array_bar.job_id} not found in qstat, but cross-check showed it is not finished"
@@ -476,7 +471,6 @@ def follow_progress(
                             f"Cross check failed for job {array_bar.job_id} 5 times in a row. Assuming it is finished."
                         )
                         array_bar.finish()
-                        array_bar.log_errors()
                 continue
 
             job_status = dict(job_info.iloc[0])
@@ -486,6 +480,7 @@ def follow_progress(
             time.sleep(update_interval)
 
     for bar in progresses:
+        bar.log_errors()
         bar.close()
 
     return

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,16 @@
+import subprocess
+
+import pytest 
+
+from hpce_utils import shell
+
+def test_subprocess_error():
+    command_fails = "this_command_does_not_exist"
+    with pytest.raises(subprocess.CalledProcessError):
+        shell.execute(command_fails, check=True)
+
+
+def test_subprocess_error_retry():
+    command_fails = "this_command_does_not_exist"
+    with pytest.raises(subprocess.CalledProcessError):
+        shell.execute_with_retry(command_fails, max_retries=0)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,8 +1,9 @@
 import subprocess
 
-import pytest 
+import pytest
 
 from hpce_utils import shell
+
 
 def test_subprocess_error():
     command_fails = "this_command_does_not_exist"

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -233,7 +233,7 @@ def test_follow_progress_with_initial_qstat_failures(caplog):
     assert "returncode" in all_logs
 
 
-def test_wait_for_jobs_without_qstat(home_tmp_path: Path):
+def test_wait_for_jobs_using_hold_job(home_tmp_path: Path):
     print("scratch:", home_tmp_path)
     log_dir = home_tmp_path / "uge_testlogs"
     script_1: str = submitting.generate_taskarray_script(
@@ -263,7 +263,7 @@ def test_wait_for_jobs_without_qstat(home_tmp_path: Path):
 
     print(job_id_1, job_id_2)
 
-    finished_file = status.wait_for_jobs_without_qstat(
+    finished_file = status.wait_for_jobs_using_hold_job(
         [job_id_1, job_id_2],
         scr=home_tmp_path,
         log_dir=log_dir,

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,10 +1,9 @@
-from unittest.mock import patch, MagicMock
 from subprocess import CalledProcessError as CPError
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hpce_utils.managers.uge import status 
-
+from hpce_utils.managers.uge import status
 
 VALID_QSTAT_OUTPUT_RUNNING = """
 job-ID     prior   name       user         state submit/start at     queue                          jclass                         slots ja-task-ID
@@ -20,16 +19,16 @@ VALID_QSTAT_OUTPUT_FINISHED = ""
 QSTATJ_OUTPUT_FINISHED = ""
 QACCTJ_OUTPUT_FINISHED = """
 ==============================================================
-qname                    some.q          
+qname                    some.q
 hostname                 some.host
-group                    some_group           
-owner                    username          
-project                  NONE                
+group                    some_group
+owner                    username
+project                  NONE
 department               some_department
-jobname                  some_name            
-jobnumber                12345678           
+jobname                  some_name
+jobnumber                12345678
 taskid                   1
-pe_taskid                NONE                
+pe_taskid                NONE
 """
 
 
@@ -68,7 +67,7 @@ def test_follow_progress():
     qacctj_finished.stdout = QACCTJ_OUTPUT_FINISHED
     qacctj_finished.stderr = ""
     qacctj_finished.returncode = 0
-    
+
     side_effects = [
         mock_proc_running,
         mock_proc_qstatj,
@@ -76,17 +75,19 @@ def test_follow_progress():
         mock_proc_finished,
         qstatj_finished_error,
         qacctj_finished,
-        qstatj_finished_error, # for array_bar.log_errors()
+        qstatj_finished_error,  # for array_bar.log_errors()
     ]
 
-    # Patch subprocess.run 
+    # Patch subprocess.run
     with patch("hpce_utils.shell.subprocess.run", side_effect=side_effects) as mock_subprocess:
         # Patch tqdm to avoid actual progress bars in test output
         with patch("hpce_utils.managers.uge.status.tqdm"):
             status.follow_progress(
-                username="username", job_ids=["12345678"], update_interval=0.1,
-                )
-        
+                username="username",
+                job_ids=["12345678"],
+                update_interval=0.1,
+            )
+
         assert mock_subprocess.call_count == 7
 
 
@@ -138,7 +139,7 @@ def test_follow_progress_with_qstat_failures(caplog):
         mock_proc_finished,
         qstatj_finished_error,
         qacctj_finished,
-        qstatj_finished_error, # for array_bar.log_errors()
+        qstatj_finished_error,  # for array_bar.log_errors()
     ]
 
     # Patch subprocess.run in the correct module
@@ -146,8 +147,10 @@ def test_follow_progress_with_qstat_failures(caplog):
         # Patch tqdm to avoid actual progress bars in test output
         with patch("hpce_utils.managers.uge.status.tqdm"):
             with caplog.at_level("WARNING", logger="hpce_utils.managers.uge.status"):
-                status.follow_progress(username="username", job_ids=["12345678"], update_interval=0.1)
-        
+                status.follow_progress(
+                    username="username", job_ids=["12345678"], update_interval=0.1
+                )
+
         assert mock_subprocess.call_count == 9
 
     # Check that the log contains the expected messages
@@ -197,17 +200,17 @@ def test_follow_progress_with_initial_qstat_failures(caplog):
 
     # The sequence: error, error, running, qstat -j, running, error, running, finished
     side_effects = [
-        qstat_error, 
-        qstat_error, 
+        qstat_error,
+        qstat_error,
         mock_proc_running,
         mock_proc_qstatj,
-        mock_proc_running, 
+        mock_proc_running,
         qstat_error,
         mock_proc_running,
         mock_proc_finished,
         qstatj_finished_error,
         qacctj_finished,
-        qstatj_finished_error, # for array_bar.log_errors()
+        qstatj_finished_error,  # for array_bar.log_errors()
     ]
 
     # Patch subprocess.run in the correct module
@@ -215,8 +218,10 @@ def test_follow_progress_with_initial_qstat_failures(caplog):
         # Patch tqdm to avoid actual progress bars in test output
         with patch("hpce_utils.managers.uge.status.tqdm"):
             with caplog.at_level("WARNING", logger="hpce_utils.managers.uge.status"):
-                status.follow_progress(username="username", job_ids=["12345678"], update_interval=0.1, exit_after=5)
-        
+                status.follow_progress(
+                    username="username", job_ids=["12345678"], update_interval=0.1, exit_after=5
+                )
+
         assert mock_subprocess.call_count == 11
 
     # Check that the log contains the expected messages
@@ -224,4 +229,3 @@ def test_follow_progress_with_initial_qstat_failures(caplog):
     assert "stdout" in all_logs
     assert "stderr" in all_logs
     assert "returncode" in all_logs
-

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,227 @@
+from unittest.mock import patch, MagicMock
+from subprocess import CalledProcessError as CPError
+
+import pytest
+
+from hpce_utils.managers.uge import status 
+
+
+VALID_QSTAT_OUTPUT_RUNNING = """
+job-ID     prior   name       user         state submit/start at     queue                          jclass                         slots ja-task-ID
+---------------------------------------------------------------------------------
+12345678   0.5019  job        username     r     05/19/2025 09:18:15 some.q@some.server.eu.                                        1     1
+"""
+QSTATJ_OUTPUT = """
+job_number:                 26936216
+submission_time:            05/19/2025 13:37:07.436
+job-array tasks:            0-1
+"""
+VALID_QSTAT_OUTPUT_FINISHED = ""
+QSTATJ_OUTPUT_FINISHED = ""
+QACCTJ_OUTPUT_FINISHED = """
+==============================================================
+qname                    some.q          
+hostname                 some.host
+group                    some_group           
+owner                    username          
+project                  NONE                
+department               some_department
+jobname                  some_name            
+jobnumber                12345678           
+taskid                   1
+pe_taskid                NONE                
+"""
+
+
+def test_qstat_error():
+    with patch("hpce_utils.shell.subprocess.run") as mock_subprocess:
+        mock_subprocess.side_effect = CPError("fail", 1)
+        with pytest.raises(CPError):
+            status.get_qstat("username", max_retries=0)
+
+
+def test_follow_progress():
+    # Prepare mock process objects
+    mock_proc_running = MagicMock()
+    mock_proc_running.stdout = VALID_QSTAT_OUTPUT_RUNNING
+    mock_proc_running.stderr = ""
+    mock_proc_running.returncode = 0
+
+    mock_proc_qstatj = MagicMock()
+    mock_proc_qstatj.stdout = QSTATJ_OUTPUT
+    mock_proc_qstatj.stderr = ""
+    mock_proc_qstatj.returncode = 0
+
+    mock_proc_finished = MagicMock()
+    mock_proc_finished.stdout = VALID_QSTAT_OUTPUT_FINISHED
+    mock_proc_finished.stderr = ""
+    mock_proc_finished.returncode = 0
+
+    qstatj_finished_error = CPError(
+        cmd="qstat -j 12345678",
+        returncode=1,
+        stderr="Following jobs do not exist or permissions are not sufficient: 12345678",
+        output="",
+    )
+
+    qacctj_finished = MagicMock()
+    qacctj_finished.stdout = QACCTJ_OUTPUT_FINISHED
+    qacctj_finished.stderr = ""
+    qacctj_finished.returncode = 0
+    
+    side_effects = [
+        mock_proc_running,
+        mock_proc_qstatj,
+        mock_proc_running,
+        mock_proc_finished,
+        qstatj_finished_error,
+        qacctj_finished,
+        qstatj_finished_error, # for array_bar.log_errors()
+    ]
+
+    # Patch subprocess.run 
+    with patch("hpce_utils.shell.subprocess.run", side_effect=side_effects) as mock_subprocess:
+        # Patch tqdm to avoid actual progress bars in test output
+        with patch("hpce_utils.managers.uge.status.tqdm"):
+            status.follow_progress(
+                username="username", job_ids=["12345678"], update_interval=0.1,
+                )
+        
+        assert mock_subprocess.call_count == 7
+
+
+def test_follow_progress_with_qstat_failures(caplog):
+    # Simulate: success, success, failure, success, finished
+
+    # Prepare mock process objects
+    mock_proc_running = MagicMock()
+    mock_proc_running.stdout = VALID_QSTAT_OUTPUT_RUNNING
+    mock_proc_running.stderr = ""
+    mock_proc_running.returncode = 0
+
+    mock_proc_qstatj = MagicMock()
+    mock_proc_qstatj.stdout = QSTATJ_OUTPUT
+    mock_proc_qstatj.stderr = ""
+    mock_proc_qstatj.returncode = 0
+
+    mock_proc_finished = MagicMock()
+    mock_proc_finished.stdout = VALID_QSTAT_OUTPUT_FINISHED
+    mock_proc_finished.stderr = ""
+    mock_proc_finished.returncode = 0
+
+    qstat_error = CPError(
+        cmd="qstat",
+        returncode=1,
+        stderr="qstat error",
+        output="",
+    )
+
+    qstatj_finished_error = CPError(
+        cmd="qstat -j 12345678",
+        returncode=1,
+        stderr="Following jobs do not exist or permissions are not sufficient: 12345678",
+        output="",
+    )
+
+    qacctj_finished = MagicMock()
+    qacctj_finished.stdout = QACCTJ_OUTPUT_FINISHED
+    qacctj_finished.stderr = ""
+    qacctj_finished.returncode = 0
+
+    # The sequence: running, qtstat -j, running, error, running, finished
+    side_effects = [
+        mock_proc_running,
+        mock_proc_qstatj,
+        mock_proc_running,
+        qstat_error,
+        mock_proc_running,
+        mock_proc_finished,
+        qstatj_finished_error,
+        qacctj_finished,
+        qstatj_finished_error, # for array_bar.log_errors()
+    ]
+
+    # Patch subprocess.run in the correct module
+    with patch("hpce_utils.shell.subprocess.run", side_effect=side_effects) as mock_subprocess:
+        # Patch tqdm to avoid actual progress bars in test output
+        with patch("hpce_utils.managers.uge.status.tqdm"):
+            with caplog.at_level("WARNING", logger="hpce_utils.managers.uge.status"):
+                status.follow_progress(username="username", job_ids=["12345678"], update_interval=0.1)
+        
+        assert mock_subprocess.call_count == 9
+
+    # Check that the log contains the expected messages
+    all_logs = caplog.text
+    assert "stdout" in all_logs
+    assert "stderr" in all_logs
+    assert "returncode" in all_logs
+
+
+def test_follow_progress_with_initial_qstat_failures(caplog):
+    # Simulate: success, success, failure, success, finished
+
+    # Prepare mock process objects
+    mock_proc_running = MagicMock()
+    mock_proc_running.stdout = VALID_QSTAT_OUTPUT_RUNNING
+    mock_proc_running.stderr = ""
+    mock_proc_running.returncode = 0
+
+    mock_proc_qstatj = MagicMock()
+    mock_proc_qstatj.stdout = QSTATJ_OUTPUT
+    mock_proc_qstatj.stderr = ""
+    mock_proc_qstatj.returncode = 0
+
+    mock_proc_finished = MagicMock()
+    mock_proc_finished.stdout = VALID_QSTAT_OUTPUT_FINISHED
+    mock_proc_finished.stderr = ""
+    mock_proc_finished.returncode = 0
+
+    qstat_error = CPError(
+        cmd="qstat",
+        returncode=1,
+        stderr="qstat error",
+        output="",
+    )
+
+    qstatj_finished_error = CPError(
+        cmd="qstat -j 12345678",
+        returncode=1,
+        stderr="Following jobs do not exist or permissions are not sufficient: 12345678",
+        output="",
+    )
+
+    qacctj_finished = MagicMock()
+    qacctj_finished.stdout = QACCTJ_OUTPUT_FINISHED
+    qacctj_finished.stderr = ""
+    qacctj_finished.returncode = 0
+
+    # The sequence: error, error, running, qstat -j, running, error, running, finished
+    side_effects = [
+        qstat_error, 
+        qstat_error, 
+        mock_proc_running,
+        mock_proc_qstatj,
+        mock_proc_running, 
+        qstat_error,
+        mock_proc_running,
+        mock_proc_finished,
+        qstatj_finished_error,
+        qacctj_finished,
+        qstatj_finished_error, # for array_bar.log_errors()
+    ]
+
+    # Patch subprocess.run in the correct module
+    with patch("hpce_utils.shell.subprocess.run", side_effect=side_effects) as mock_subprocess:
+        # Patch tqdm to avoid actual progress bars in test output
+        with patch("hpce_utils.managers.uge.status.tqdm"):
+            with caplog.at_level("WARNING", logger="hpce_utils.managers.uge.status"):
+                status.follow_progress(username="username", job_ids=["12345678"], update_interval=0.1, exit_after=5)
+        
+        assert mock_subprocess.call_count == 11
+
+    # Check that the log contains the expected messages
+    all_logs = caplog.text
+    assert "stdout" in all_logs
+    assert "stderr" in all_logs
+    assert "returncode" in all_logs
+

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,9 +1,11 @@
+import os
+from pathlib import Path
 from subprocess import CalledProcessError as CPError
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hpce_utils.managers.uge import status
+from hpce_utils.managers.uge import status, submitting
 
 VALID_QSTAT_OUTPUT_RUNNING = """
 job-ID     prior   name       user         state submit/start at     queue                          jclass                         slots ja-task-ID
@@ -229,3 +231,51 @@ def test_follow_progress_with_initial_qstat_failures(caplog):
     assert "stdout" in all_logs
     assert "stderr" in all_logs
     assert "returncode" in all_logs
+
+
+def test_wait_for_jobs_without_qstat(home_tmp_path: Path):
+    print("scratch:", home_tmp_path)
+    log_dir = home_tmp_path / "uge_testlogs"
+    script_1: str = submitting.generate_taskarray_script(
+        "sleep 10",
+        cores=1,
+        cwd=home_tmp_path,
+        log_dir=log_dir,
+        name="TestJob",
+        task_concurrent=1,
+        task_stop=1,
+    )
+
+    script_2: str = submitting.generate_taskarray_script(
+        "sleep 9",
+        cores=1,
+        cwd=home_tmp_path,
+        log_dir=log_dir,
+        name="TestJob2",
+        task_concurrent=1,
+        task_stop=1,
+    )
+
+    job_id_1, _ = submitting.submit_script(script_1, scr=home_tmp_path)
+    job_id_2, _ = submitting.submit_script(script_2, scr=home_tmp_path)
+    assert job_id_1 is not None
+    assert job_id_2 is not None
+
+    print(job_id_1, job_id_2)
+
+    finished_file = status.wait_for_jobs_without_qstat(
+        [job_id_1, job_id_2],
+        scr=home_tmp_path,
+        log_dir=log_dir,
+        update_interval=5,
+    )
+
+    assert finished_file.exists()
+
+    username = os.getenv("USER")
+    assert username is not None
+    qstat, log_str = status.get_qstat(username, max_retries=0)
+    print(log_str)
+
+    assert job_id_1 not in qstat["job"]
+    assert job_id_2 not in qstat["job"]

--- a/tests/test_uge.py
+++ b/tests/test_uge.py
@@ -51,9 +51,9 @@ def test_taskarray(home_tmp_path: Path):
 
     # Wait
     finished_job_id: str | None = None
-    for finished_job_id in status.wait_for_jobs([job_id], respiratory=10):
+    for finished_job_id_ in status.wait_for_jobs([job_id], respiratory=10):
         print(f"job {finished_job_id} finished")
-        finished_job_id = finished_job_id
+        finished_job_id = finished_job_id_
 
     assert finished_job_id is not None
     stdout, stderr = submitting.read_logfiles(log_dir, finished_job_id, ignore_stdout=False)
@@ -75,8 +75,8 @@ def test_taskarray(home_tmp_path: Path):
             assert False, f"Unexpected line in log file: {line}"
 
     # Parse output
-    for _, line in stdout.items():
-        assert success_string in line
+    for _, lines in stdout.items():
+        assert success_string in lines
 
 
 @pytest.mark.skip(reason="Not implemented")
@@ -165,7 +165,7 @@ def test_failed_command(home_tmp_path: Path):
             if "=>" in line:
                 continue
             filtered_stderr[file].append(line)
-    
+
     assert len(filtered_stderr) == 1
 
 

--- a/tests/test_uge.py
+++ b/tests/test_uge.py
@@ -197,7 +197,6 @@ def test_failed_uge_submit(tmp_path: Path, caplog):
 
     assert job_id is not None
     print(job_id)
-    time.sleep(15)
 
     with caplog.at_level(logging.WARNING):
         status.follow_progress(job_ids=[job_id])

--- a/tests/test_uge.py
+++ b/tests/test_uge.py
@@ -197,6 +197,7 @@ def test_failed_uge_submit(tmp_path: Path, caplog):
 
     assert job_id is not None
     print(job_id)
+    time.sleep(15)
 
     with caplog.at_level(logging.WARNING):
         status.follow_progress(job_ids=[job_id])


### PR DESCRIPTION
I have observed cases, where the 
status.follow_progress function has indicated that jobs were finished, when I could reconstruct that they had not been finishes at the time. The reason for this is unclear as of yet, it is not due to qstat exiting with a non-zero return code, the log files should have reflected that, but did not. 

This PR addresses these problems: 
* the follow_status function is made more robust by cross-checking qstat -j and qacct -j in order to make sure that the job has finished. The logging is extended as well
* I have added tests to make sure errors are caught and handled as expected. 
* Moreover I add a different way to wait for a job to finish which relies on a hold job, and avoids qstat altogether